### PR TITLE
feat: extend join tables config for types

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The built-in SilverStripe search form is a very simple search engine. This plugi
   * `ClassName`: full ClassName
   * `ClassNameShort`: namespaced ClassName
   * `Filters`: a list of filters to apply pre-search (maps to `DataList->Filter(key => value)`)
+  * `JoinTables`: Join Tables. (format `JoinTable` or `JoinTable.Column` or `JoinTable.Column: JoinTableOn.Column` or `JoinTable: [JoinTableFrom.Column: JoinTableOn.Column]`. Look below for examples)
   * `Columns`: columns to search for query string matches (format `Table.Column`)
 * `filters`: associative list of filter options
   * `Structure`: defines the filter's relational structure (must be one of `db`, `has_one` or `many_many`)
@@ -51,7 +52,7 @@ TODO: `defaults`: Default attributes or settings, as opposed to those submitted 
 
 # Example configuration
 
-```
+```yml
 ---
 Name: search
 Before:
@@ -76,6 +77,18 @@ PlasticStudio\Search\SearchPageController:
       Filters: 
         SiteTree_Live.ShowInSearch: '1'
       JoinTables: ['SiteTree_Live']
+      # Another possible syntax (same result like above):
+      # JoinTables: ['SiteTree_Live.ID']
+
+      # Another possible syntax (same result like above):
+      # JoinTables:
+      #   - "SiteTreeLive.ID": "Page.ID"
+
+      # Another possible syntax (same result like above):
+      # JoinTables:
+      #   - "SiteTreeLive":
+      #     - "SiteTreeLive.ID": "Page.ID"
+      
       Columns: ['SiteTree_Live.Title','SiteTree_Live.MenuTitle','SiteTree_Live.Content', 'SiteTree_Live.ElementalSearchContent']
   filters:
     updated_before:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -27,6 +27,15 @@ SilverStripe\CMS\Model\SiteTree:
   #     Filters: 
   #       SiteTree_Live.ShowInSearch: '1'
   #     JoinTables: ['SiteTree_Live']
+  #       # Same result as above
+  # #     JoinTables: ['SiteTree_Live.ID'] # Same result as above
+  #       # Same result as above
+  # #     JoinTables:
+  # #       - 'SiteTree_Live.ID': 'Page_Live.ID'
+  #       # Same result as above
+  # #     JoinTables:
+  # #       - 'SiteTree_Live':
+  # #           'SiteTree_Live.ID': 'Page_Live.ID'
   #     Columns: ['SiteTree_Live.Title','SiteTree_Live.MetaDescription','SiteTree_Live.MenuTitle','SiteTree_Live.Content']
   # filters:
   #   edited_before:


### PR DESCRIPTION
This pull request would give us more flexibility with JoinTables.

After it the following values would be allowed:

```yml
JoinTables: ['SiteTree_Live']
```

```yml
JoinTables: ['SiteTree_Live.ID']
```

```yml
JoinTables:
  - "SiteTreeLive.ID": "Page.ID"
```

```yml
JoinTables:
  - "SiteTreeLive":
    - "SiteTreeLive.ID": "Page.ID"
```

All of the would produce the same output